### PR TITLE
Set html_class to has-many

### DIFF
--- a/lib/administrate/field/scoped_belongs_to.rb
+++ b/lib/administrate/field/scoped_belongs_to.rb
@@ -1,0 +1,36 @@
+require 'administrate/field/belongs_to'
+require 'administrate/field/scoped_has_many/version'
+require 'rails/engine'
+
+module Administrate
+  module Field
+    class ScopedBelongsTo < Administrate::Field::BelongsTo
+      include ScopedHasManyVersion
+
+      class Engine < ::Rails::Engine
+      end
+
+      def to_s
+        data
+      end
+
+      def to_partial_path
+        "/fields/#{self.class.superclass.field_type}/#{page}"
+      end
+
+      def self.html_class
+        "belongs-to"
+      end
+
+      private
+
+      def candidate_resources
+        scope = options[:scope] ? options[:scope].call(self) : associated_class.all
+        scope = scope.includes(*options.fetch(:includes)) if options.key?(:includes)
+
+        order = options.delete(:order)
+        order ? scope.reorder(order) : scope
+      end
+    end
+  end
+end

--- a/lib/administrate/field/scoped_has_many.rb
+++ b/lib/administrate/field/scoped_has_many.rb
@@ -18,6 +18,10 @@ module Administrate
         "/fields/#{self.class.superclass.field_type}/#{page}"
       end
 
+      def self.html_class
+        "has-many"
+      end
+
       private
 
       def candidate_resources

--- a/lib/administrate/field/scoped_has_many/version.rb
+++ b/lib/administrate/field/scoped_has_many/version.rb
@@ -1,7 +1,7 @@
 module Administrate
   module Field
     module ScopedHasManyVersion
-      VERSION = '0.2.0'.freeze
+      VERSION = '0.3.0'.freeze
     end
   end
 end


### PR DESCRIPTION
This way, selectize [is automatically used](https://github.com/thoughtbot/administrate/blob/21c52889445d56d409fe30d1081b651252390baa/app/assets/javascripts/administrate/components/associative.js#L3) for selects created with scoped has_many.

There is probably no need to have `field-unit--scoped-has-many` in the HTML markup. The frontend should not care if the field is scope under the hood. 